### PR TITLE
Fixed issue with adding an existing user to rstudioGroup

### DIFF
--- a/data_science_desktop.sh
+++ b/data_science_desktop.sh
@@ -48,7 +48,7 @@ echo ""
 sudo groupadd $rstudioGroup
 sudo useradd -m -N $rstudioUser
 echo "$rstudioUser:$rstudioPassword" | sudo chpasswd
-sudo usermod -G $rstudioGroup $rstudioUser
+sudo usermod -a -G $rstudioGroup $rstudioUser
 sudo chmod -R +u+r+w /home/$rstudioUser
 
 echo ""

--- a/data_science_workbench.sh
+++ b/data_science_workbench.sh
@@ -48,7 +48,7 @@ echo ""
 sudo groupadd $rstudioGroup
 sudo useradd -m -N $rstudioUser
 echo "$rstudioUser:$rstudioPassword" | sudo chpasswd
-sudo usermod -G $rstudioGroup $rstudioUser
+sudo usermod -a -G $rstudioGroup $rstudioUser
 sudo chmod -R +u+r+w /home/$rstudioUser
 
 echo ""


### PR DESCRIPTION
When running this script using my existing user for $rstudioUser, I lost sudo privileges on reboot. The cause is the usermod call to add $rstudioUser to $rstudioGroup without the -a option. This caused my user to be removed from all groups except for the $rstudioGroup.

Thanks for the script. It helped me stand up a computer very quickly. It introduced me to your blog which I plan to follow in the future.

Paul Cartwright
